### PR TITLE
Basic WebMIDI functionality

### DIFF
--- a/keys.htm
+++ b/keys.htm
@@ -16,6 +16,7 @@
 
 	<script src="QueryData.js"></script>
 	<script src="jscolor.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/webmidi@latest/dist/iife/webmidi.iife.min.js"></script>
 </head>
 
 <body style="overflow: scroll;">


### PR DESCRIPTION
Hello, I added basic WebMIDI functionality to this webapp for use with MTS-ESP-compatible synthesizers. I output to a virtual [loopMIDI](https://www.tobias-erichsen.de/software/loopmidi.html) port, which I use to pass the MIDI data through to a virtual synthesizer running in my DAW alongside [MTS-ESP mini](https://oddsound.com/mtsespmini.php) loaded up with the .scl file supplied by the webapp. This pull request is lacking any sort of documentation for the user but I wanted to see if it was something you would be interested in pulling. I do not consider myself a programmer, so please be scrutinous with this code.